### PR TITLE
Activate es2015 in mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dist": "ulimit -n 2560 && ./node_modules/.bin/browserify -d -s chrome -e lib/chrome.js -o demo/chrome_es5.js -t [ babelify --presets [ es2015 ] --sourceMapRelative . ]",
     "test": "npm run lint && npm run test-nocover",
-    "test-nocover": "node_modules/.bin/_mocha --compilers js:babel-core/register --require ./test/_setup.js 'test/**/*_test.js'",
+    "test-nocover": "node_modules/.bin/_mocha --require ./test/_setup.js 'test/**/*_test.js'",
     "lint": "eslint lib/"
   },
   "repository": {

--- a/test/_setup.js
+++ b/test/_setup.js
@@ -1,6 +1,13 @@
 "use strict";
 
 /**
+ * Activate transpilation before running tests.
+ */
+require("babel-core/register")({
+  presets: ["es2015"]
+});
+
+/**
  * Test environment setup.
  *
  * In FakeIndexedDB, symbols are exposed using ``FDB`` prefixes in names.


### PR DESCRIPTION
Running the mocha tests requires es2015-babel, and for some reason the `--compilers js:babel-core/register` option didn't work for me when I tried it, so I moved this to `test/_setup.js`.

This is how kinto.js does it as well.

r? @n1k0 
