### PR TITLE
Add demo/chrome_es5.js to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .*.un~
+demo/chrome_es5.js


### PR DESCRIPTION
This file is generated during `npm run dist`, so it's nice to have it in `.gitignore`.

r? @n1k0 
