### PR TITLE
Add chrome.storage.sync.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ kinto-chrome
 Prototype project to build a [chrome.storage.sync](https://developer.chrome.com/extensions/storage)
 compatible wrapper around Kinto.js.
 
+To make it sync to a Kinto server, configure as follows:
+
+````js
+chrome.storage.sync.config = {
+  type: "kinto",
+  interval: 60000, // milliseconds
+  remote: "http://localhost:8080/v1",
+  headers: {Authorization: "Basic " + btoa("user:pass")}
+};
+````

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,6 +10,13 @@
     <!--script src="kinto-1.1.1.js"></script-->
     <script src="chrome_es5.js"></script>
     <script>
+      chrome.storage.sync.config = {
+         type: "kinto",
+         interval: 6000, // milliseconds
+         remote: "https://kinto.dev.mozaws.net/v1",
+         headers: {Authorization: "Basic " + btoa("user:pass")}
+      };
+
       // example from the https://developer.chrome.com/extensions/storage page
       function saveChanges() {
         // Get a value saved in a form.

--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -56,19 +56,15 @@ class Events {
 
 }
 
+const MIN_INTERVAL = 1000;
 
 export class StorageArea {
-  constructor(endpoint, areaName) {
-    if (!endpoint) {endpoint = "http://localhost:8080/v1/";}
-    this.endpoint = endpoint;
 
+  constructor(areaName) {
     if (!areaName) {areaName = "sync";}
     this.areaName = areaName;
 
-    this.db = new Kinto({
-      remote: endpoint,
-      headers: {Authorization: "Basic dXNlcjpwYXNz"},
-    });
+    this.db = new Kinto();
 
     function schema() {
       let _next = 0;
@@ -84,6 +80,45 @@ export class StorageArea {
     }
 
     this.items = this.db.collection("items", {idSchema: schema()});
+  }
+
+  get config() {
+    return this._config;
+  }
+
+  _sync () {
+    console.warn("Sync not implemented yet");
+    return Promise.resolve();
+  }
+
+  set config(config) {
+    if (this.areaName !== "sync") {
+      return;
+    }
+    if (typeof config !== "object") {
+      throw new Error("config should be an object");
+    }
+    if (config.type !== "kinto") {
+      throw new Error("Unsupported type, try setting chrome.storage.sync.config.type = \"kinto\".");
+    }
+
+    this._config = config;
+
+    if (typeof config.interval === "number") {
+      if (config.interval < MIN_INTERVAL) {
+        console.error(`Sync interval should be at least ${MIN_INTERVAL} milliseconds`);
+        return;
+      }
+      this._sync().then(() => {
+        this.syncTimer = setInterval(() => {
+          this._sync().catch(err => {
+            console.error("Sync Error", err.message);
+          });
+        }, config.interval);
+      }, err => {
+        console.error("Sync Disabled", err.message);
+      });
+    }
   }
 
   get(keys, callback) {
@@ -189,6 +224,6 @@ export class StorageArea {
 
 
 export const storage = {onChanged: new Events(),
-                        sync: new StorageArea("http://localhost:8080/v1/", "sync"),
-                        local: new StorageArea("http://localhost:8080/v1/", "local"),
-                        managed: new StorageArea("http://localhost:8080/v1/", "managed")};
+                        sync: new StorageArea("sync"),
+                        local: new StorageArea("local"),
+                        managed: new StorageArea("managed")};

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-core": ">=6.3.13",
     "babel-cli": ">=6.3.13",
     "btoa": "^1.1.2",
-    "kinto": "^1.1.2",
+    "kinto": "^1.2.0",
     "fake-indexeddb": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
TO DO:
- [x] Add test for call to `setInterval`
- [x] Input checking
- [x] Remove `console.log` statement
- [x] ~~Change `console.error` call to proper error management (see https://github.com/Kinto/kinto-chrome/issues/2)~~ -> follow-up
- [x] Remove use of `btoa` for the default config
- [x] Add docs
- [x] Rebase the two unrelated commits out of this branch
