### PR TITLE
Throw errors when setting config, fixes #2

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -134,8 +134,7 @@ export class StorageArea {
 
     if (typeof config.interval === "number") {
       if (config.interval < MIN_INTERVAL) {
-        console.error(`Sync interval should be at least ${MIN_INTERVAL} milliseconds`);
-        return;
+        throw new Error(`Sync interval should be at least ${MIN_INTERVAL} milliseconds`);
       }
 
       // Start sync

--- a/test/chrome_test.js
+++ b/test/chrome_test.js
@@ -135,13 +135,25 @@ describe("StorageArea", function() {
       }); // give time for call to stubbed sync method to complete
     });
 
-    it("should respect MIN_INTERVAL of 1000ms", function(done) {
-      area.config = { type: "kinto", interval: 123 };
-      expect(consoleSpy
-          .calledWith("Sync interval should be at least 1000 milliseconds"))
-          .to.eql(true);
+    it("checks config is an object", function() {
+      expect(function() {
+        area.config = 42;
+      }).to.Throw(Error, "config should be an object");
       expect(syncStub.called).to.eql(false);
-      done();
+    });
+
+    it("checks type equals \"kinto\"", function() {
+      expect(function() {
+        area.config = { type: "foo", interval: 123000 };
+      }).to.Throw(Error, /Unsupported type/);
+      expect(syncStub.called).to.eql(false);
+    });
+
+    it("checks MIN_INTERVAL of 1000ms", function() {
+      expect(function() {
+        area.config = { type: "kinto", interval: 123 };
+      }).to.Throw(Error, /at least 1000/);
+      expect(syncStub.called).to.eql(false);
     });
   });
 


### PR DESCRIPTION
~~This is a minimal first implementation to "plant a flag", will do follow-ups to make `extension` not be a singleton (see #24) and to make sure it behaves exactly `chrome.extension.lastError`.~~

As per https://github.com/Kinto/kinto-chrome/issues/2#issuecomment-185199247
